### PR TITLE
Made to match Oasis convention (BUY ETH, SELL SAI). Adjust spread semantics.

### DIFF
--- a/keepers/sai_maker_otc.py
+++ b/keepers/sai_maker_otc.py
@@ -91,11 +91,11 @@ class SaiMakerOtc(SaiKeeper):
     def our_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.owner == self.our_address, active_offers))
 
-    def our_buy_offers(self, active_offers: list):
+    def our_sell_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.sai.address and
                                          offer.sell_which_token == self.gem.address, self.our_offers(active_offers)))
 
-    def our_sell_offers(self, active_offers: list):
+    def our_buy_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.gem.address and
                                          offer.sell_which_token == self.sai.address, self.our_offers(active_offers)))
 
@@ -110,8 +110,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return buy offers with rates outside allowed margin range."""
         for offer in self.our_buy_offers(active_offers):
             rate = self.rate_buy(offer)
-            rate_min = self.apply_buy_margin(self.target_rate(), self.min_margin)
-            rate_max = self.apply_buy_margin(self.target_rate(), self.max_margin)
+            rate_min = self.apply_buy_margin(self.target_price(), self.min_margin)
+            rate_max = self.apply_buy_margin(self.target_price(), self.max_margin)
             if (rate < rate_max) or (rate > rate_min):
                 yield offer
 
@@ -119,8 +119,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return sell offers with rates outside allowed margin range."""
         for offer in self.our_sell_offers(active_offers):
             rate = self.rate_sell(offer)
-            rate_min = self.apply_sell_margin(self.target_rate(), self.min_margin)
-            rate_max = self.apply_sell_margin(self.target_rate(), self.max_margin)
+            rate_min = self.apply_sell_margin(self.target_price(), self.min_margin)
+            rate_max = self.apply_sell_margin(self.target_price(), self.max_margin)
             if (rate < rate_min) or (rate > rate_max):
                 yield offer
 
@@ -133,31 +133,31 @@ class SaiMakerOtc(SaiKeeper):
         synchronize([transact.transact_async(self.default_options())
                      for transact in chain(self.new_buy_offer(active_offers), self.new_sell_offer(active_offers))])
 
-    def new_buy_offer(self, active_offers: list):
+    def new_sell_offer(self, active_offers: list):
         """If our WETH engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_buy_offers(active_offers))
+        total_amount = self.total_amount(self.our_sell_offers(active_offers))
         if total_amount < self.min_weth_amount:
             our_balance = self.gem.balance_of(self.our_address)
             have_amount = Wad.min(self.max_weth_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount / self.apply_buy_margin(self.target_rate(), self.avg_margin)
+                want_amount = have_amount * self.apply_buy_margin(self.target_price(), self.avg_margin)
                 yield self.otc.make(have_token=self.gem.address, have_amount=have_amount,
                                     want_token=self.sai.address, want_amount=want_amount)
 
-    def new_sell_offer(self, active_offers: list):
+    def new_buy_offer(self, active_offers: list):
         """If our SAI engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_sell_offers(active_offers))
+        total_amount = self.total_amount(self.our_buy_offers(active_offers))
         if total_amount < self.min_sai_amount:
             our_balance = self.sai.balance_of(self.our_address)
             have_amount = Wad.min(self.max_sai_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount * self.apply_sell_margin(self.target_rate(), self.avg_margin)
+                want_amount = have_amount / self.apply_sell_margin(self.target_price(), self.avg_margin)
                 yield self.otc.make(have_token=self.sai.address, have_amount=have_amount,
                                     want_token=self.gem.address, want_amount=want_amount)
 
-    def target_rate(self) -> Wad:
+    def target_price(self) -> Wad:
         ref_per_gem = Wad(DSValue(web3=self.web3, address=self.tub.pip()).read_as_int())
-        return self.tub.par() / ref_per_gem
+        return ref_per_gem / self.tub.par()
 
     @staticmethod
     def rate_buy(offer: OfferInfo) -> Wad:

--- a/keepers/sai_maker_otc.py
+++ b/keepers/sai_maker_otc.py
@@ -91,11 +91,11 @@ class SaiMakerOtc(SaiKeeper):
     def our_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.owner == self.our_address, active_offers))
 
-    def our_sell_offers(self, active_offers: list):
+    def our_buy_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.sai.address and
                                          offer.sell_which_token == self.gem.address, self.our_offers(active_offers)))
 
-    def our_buy_offers(self, active_offers: list):
+    def our_sell_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.gem.address and
                                          offer.sell_which_token == self.sai.address, self.our_offers(active_offers)))
 
@@ -110,8 +110,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return buy offers with rates outside allowed margin range."""
         for offer in self.our_buy_offers(active_offers):
             rate = self.rate_buy(offer)
-            rate_min = self.apply_buy_margin(self.target_price(), self.min_margin)
-            rate_max = self.apply_buy_margin(self.target_price(), self.max_margin)
+            rate_min = self.apply_buy_margin(self.target_rate(), self.min_margin)
+            rate_max = self.apply_buy_margin(self.target_rate(), self.max_margin)
             if (rate < rate_max) or (rate > rate_min):
                 yield offer
 
@@ -119,8 +119,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return sell offers with rates outside allowed margin range."""
         for offer in self.our_sell_offers(active_offers):
             rate = self.rate_sell(offer)
-            rate_min = self.apply_sell_margin(self.target_price(), self.min_margin)
-            rate_max = self.apply_sell_margin(self.target_price(), self.max_margin)
+            rate_min = self.apply_sell_margin(self.target_rate(), self.min_margin)
+            rate_max = self.apply_sell_margin(self.target_rate(), self.max_margin)
             if (rate < rate_min) or (rate > rate_max):
                 yield offer
 
@@ -133,31 +133,31 @@ class SaiMakerOtc(SaiKeeper):
         synchronize([transact.transact_async(self.default_options())
                      for transact in chain(self.new_buy_offer(active_offers), self.new_sell_offer(active_offers))])
 
-    def new_sell_offer(self, active_offers: list):
+    def new_buy_offer(self, active_offers: list):
         """If our WETH engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_sell_offers(active_offers))
+        total_amount = self.total_amount(self.our_buy_offers(active_offers))
         if total_amount < self.min_weth_amount:
             our_balance = self.gem.balance_of(self.our_address)
             have_amount = Wad.min(self.max_weth_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount * self.apply_buy_margin(self.target_price(), self.avg_margin)
+                want_amount = have_amount / self.apply_buy_margin(self.target_rate(), self.avg_margin)
                 yield self.otc.make(have_token=self.gem.address, have_amount=have_amount,
                                     want_token=self.sai.address, want_amount=want_amount)
 
-    def new_buy_offer(self, active_offers: list):
+    def new_sell_offer(self, active_offers: list):
         """If our SAI engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_buy_offers(active_offers))
+        total_amount = self.total_amount(self.our_sell_offers(active_offers))
         if total_amount < self.min_sai_amount:
             our_balance = self.sai.balance_of(self.our_address)
             have_amount = Wad.min(self.max_sai_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount / self.apply_sell_margin(self.target_price(), self.avg_margin)
+                want_amount = have_amount * self.apply_sell_margin(self.target_rate(), self.avg_margin)
                 yield self.otc.make(have_token=self.sai.address, have_amount=have_amount,
                                     want_token=self.gem.address, want_amount=want_amount)
 
-    def target_price(self) -> Wad:
+    def target_rate(self) -> Wad:
         ref_per_gem = Wad(DSValue(web3=self.web3, address=self.tub.pip()).read_as_int())
-        return ref_per_gem / self.tub.par()
+        return self.tub.par() / ref_per_gem
 
     @staticmethod
     def rate_buy(offer: OfferInfo) -> Wad:


### PR DESCRIPTION
Since the keeper was designed before the convention "BUY ETH and SELL SAI" was agreed upon for Oasis, the language in the code was the other way around to the one that was ultimately chosen. This renames everything to match Oasis semantics. Moreover, the spread parameter was previously being calculated as a spread from the `gem_per_sai` rate, this commit changes it to be a spread from the `sai_per_gem` rate instead, which is also more intuitive given the Oasis convention. 

Also rename `target_rate()` to `target_price()` to avoid confusion with `way`.

**WARNING: this commit actually changes the meaning of the min,avg,max spread parameters.**