### PR TITLE
Add (optional) rounding of order price/size

### DIFF
--- a/api/numeric.py
+++ b/api/numeric.py
@@ -112,6 +112,9 @@ class Wad:
             return self.value < other.value
         else:
             raise ArithmeticError
+        
+    def __round__(self, ndigits):
+        return Wad(round(self.value, -18 + ndigits))
 
     @staticmethod
     def min(*args):

--- a/api/test_numeric.py
+++ b/api/test_numeric.py
@@ -389,5 +389,3 @@ class TestRay:
             Ray.max(Ray(10), 20)
         with pytest.raises(ArithmeticError):
             Ray.max(15, Ray(25))
-        
-    

--- a/api/test_numeric.py
+++ b/api/test_numeric.py
@@ -204,6 +204,18 @@ class TestWad:
         with pytest.raises(ArithmeticError):
             Wad.max(15, Wad(25))
 
+    def test_round(self):
+        assert round(Wad.from_number(123.4567), 2) == Wad.from_number(123.46)
+        assert round(Wad.from_number(123.4567), 0) == Wad.from_number(123.0)
+        assert round(Wad.from_number(123.4567), -2) == Wad.from_number(100.0)
+
+    def test_round_inequality(self):
+        # should hold for all x, ndigits
+        x = Wad.from_number(7654.321)
+        ndigits = 1
+        round_difference = x - round(x, ndigits)
+        round_distance = Wad(abs(round_difference.value))
+        assert round_distance <= Wad.from_number(0.5 * 10**(-ndigits))    
 
 class TestRay:
     def test_should_support_negative_values(self):
@@ -377,3 +389,5 @@ class TestRay:
             Ray.max(Ray(10), 20)
         with pytest.raises(ArithmeticError):
             Ray.max(15, Ray(25))
+        
+    

--- a/keepers/sai_maker_otc.py
+++ b/keepers/sai_maker_otc.py
@@ -60,6 +60,7 @@ class SaiMakerOtc(SaiKeeper):
         self.min_margin = self.arguments.min_margin
         self.avg_margin = self.arguments.avg_margin
         self.max_margin = self.arguments.max_margin
+        self.round_places = self.arguments.round_places
 
     def args(self, parser: argparse.ArgumentParser):
         parser.add_argument("--min-margin", help="Minimum margin allowed", type=float, required=True)
@@ -69,6 +70,7 @@ class SaiMakerOtc(SaiKeeper):
         parser.add_argument("--min-weth-amount", help="Minimum value of open WETH sell orders", type=float, required=True)
         parser.add_argument("--max-sai-amount", help="Maximum value of open SAI sell orders", type=float, required=True)
         parser.add_argument("--min-sai-amount", help="Minimum value of open SAI sell orders", type=float, required=True)
+        parser.add_argument("--round-places", help="Number of decimal places to round order prices to (default=2)", type=int, default=2)
 
     def startup(self):
         self.approve()
@@ -140,7 +142,7 @@ class SaiMakerOtc(SaiKeeper):
             our_balance = self.gem.balance_of(self.our_address)
             have_amount = Wad.min(self.max_weth_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount / self.apply_buy_margin(self.target_rate(), self.avg_margin)
+                want_amount = have_amount / round(self.apply_buy_margin(self.target_rate(), self.avg_margin), self.round_places)
                 yield self.otc.make(have_token=self.gem.address, have_amount=have_amount,
                                     want_token=self.sai.address, want_amount=want_amount)
 
@@ -151,7 +153,7 @@ class SaiMakerOtc(SaiKeeper):
             our_balance = self.sai.balance_of(self.our_address)
             have_amount = Wad.min(self.max_sai_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount * self.apply_sell_margin(self.target_rate(), self.avg_margin)
+                want_amount = have_amount * round(self.apply_sell_margin(self.target_rate(), self.avg_margin), self.round_places)
                 yield self.otc.make(have_token=self.sai.address, have_amount=have_amount,
                                     want_token=self.gem.address, want_amount=want_amount)
 

--- a/keepers/sai_maker_otc.py
+++ b/keepers/sai_maker_otc.py
@@ -142,7 +142,7 @@ class SaiMakerOtc(SaiKeeper):
             our_balance = self.gem.balance_of(self.our_address)
             have_amount = Wad.min(self.max_weth_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount * self.apply_sell_margin(self.target_price(), self.avg_margin)
+                want_amount = have_amount * round(self.apply_sell_margin(self.target_price(), self.avg_margin), self.round_places)
                 yield self.otc.make(have_token=self.gem.address, have_amount=have_amount,
                                     want_token=self.sai.address, want_amount=want_amount)
 
@@ -153,7 +153,7 @@ class SaiMakerOtc(SaiKeeper):
             our_balance = self.sai.balance_of(self.our_address)
             have_amount = Wad.min(self.max_sai_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount / self.apply_buy_margin(self.target_price(), self.avg_margin)
+                want_amount = have_amount / round(self.apply_buy_margin(self.target_price(), self.avg_margin), self.round_places)
                 yield self.otc.make(have_token=self.sai.address, have_amount=have_amount,
                                     want_token=self.gem.address, want_amount=want_amount)
 

--- a/keepers/sai_maker_otc.py
+++ b/keepers/sai_maker_otc.py
@@ -93,11 +93,11 @@ class SaiMakerOtc(SaiKeeper):
     def our_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.owner == self.our_address, active_offers))
 
-    def our_buy_offers(self, active_offers: list):
+    def our_sell_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.sai.address and
                                          offer.sell_which_token == self.gem.address, self.our_offers(active_offers)))
 
-    def our_sell_offers(self, active_offers: list):
+    def our_buy_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.gem.address and
                                          offer.sell_which_token == self.sai.address, self.our_offers(active_offers)))
 
@@ -112,8 +112,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return buy offers with rates outside allowed margin range."""
         for offer in self.our_buy_offers(active_offers):
             rate = self.rate_buy(offer)
-            rate_min = self.apply_buy_margin(self.target_rate(), self.min_margin)
-            rate_max = self.apply_buy_margin(self.target_rate(), self.max_margin)
+            rate_min = self.apply_buy_margin(self.target_price(), self.min_margin)
+            rate_max = self.apply_buy_margin(self.target_price(), self.max_margin)
             if (rate < rate_max) or (rate > rate_min):
                 yield offer
 
@@ -121,8 +121,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return sell offers with rates outside allowed margin range."""
         for offer in self.our_sell_offers(active_offers):
             rate = self.rate_sell(offer)
-            rate_min = self.apply_sell_margin(self.target_rate(), self.min_margin)
-            rate_max = self.apply_sell_margin(self.target_rate(), self.max_margin)
+            rate_min = self.apply_sell_margin(self.target_price(), self.min_margin)
+            rate_max = self.apply_sell_margin(self.target_price(), self.max_margin)
             if (rate < rate_min) or (rate > rate_max):
                 yield offer
 
@@ -135,31 +135,37 @@ class SaiMakerOtc(SaiKeeper):
         synchronize([transact.transact_async(self.default_options())
                      for transact in chain(self.new_buy_offer(active_offers), self.new_sell_offer(active_offers))])
 
-    def new_buy_offer(self, active_offers: list):
+    def new_sell_offer(self, active_offers: list):
         """If our WETH engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_buy_offers(active_offers))
+        total_amount = self.total_amount(self.our_sell_offers(active_offers))
         if total_amount < self.min_weth_amount:
             our_balance = self.gem.balance_of(self.our_address)
             have_amount = Wad.min(self.max_weth_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount / round(self.apply_buy_margin(self.target_rate(), self.avg_margin), self.round_places)
+<<<<<<< HEAD
+=======
+                want_amount = have_amount * self.apply_sell_margin(self.target_price(), self.avg_margin)
+>>>>>>> fac8419... (Fixed) match Oasis buy/sell convention; changed spread semantics
                 yield self.otc.make(have_token=self.gem.address, have_amount=have_amount,
                                     want_token=self.sai.address, want_amount=want_amount)
 
-    def new_sell_offer(self, active_offers: list):
+    def new_buy_offer(self, active_offers: list):
         """If our SAI engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_sell_offers(active_offers))
+        total_amount = self.total_amount(self.our_buy_offers(active_offers))
         if total_amount < self.min_sai_amount:
             our_balance = self.sai.balance_of(self.our_address)
             have_amount = Wad.min(self.max_sai_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount * round(self.apply_sell_margin(self.target_rate(), self.avg_margin), self.round_places)
+<<<<<<< HEAD
+=======
+                want_amount = have_amount / self.apply_buy_margin(self.target_price(), self.avg_margin)
+>>>>>>> fac8419... (Fixed) match Oasis buy/sell convention; changed spread semantics
                 yield self.otc.make(have_token=self.sai.address, have_amount=have_amount,
                                     want_token=self.gem.address, want_amount=want_amount)
 
-    def target_rate(self) -> Wad:
+    def target_price(self) -> Wad:
         ref_per_gem = Wad(DSValue(web3=self.web3, address=self.tub.pip()).read_as_int())
-        return self.tub.par() / ref_per_gem
+        return ref_per_gem / self.tub.par()
 
     @staticmethod
     def rate_buy(offer: OfferInfo) -> Wad:

--- a/keepers/sai_maker_otc.py
+++ b/keepers/sai_maker_otc.py
@@ -91,11 +91,11 @@ class SaiMakerOtc(SaiKeeper):
     def our_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.owner == self.our_address, active_offers))
 
-    def our_buy_offers(self, active_offers: list):
+    def our_sell_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.sai.address and
                                          offer.sell_which_token == self.gem.address, self.our_offers(active_offers)))
 
-    def our_sell_offers(self, active_offers: list):
+    def our_buy_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.gem.address and
                                          offer.sell_which_token == self.sai.address, self.our_offers(active_offers)))
 
@@ -110,8 +110,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return buy offers with rates outside allowed margin range."""
         for offer in self.our_buy_offers(active_offers):
             rate = self.rate_buy(offer)
-            rate_min = self.apply_buy_margin(self.target_rate(), self.min_margin)
-            rate_max = self.apply_buy_margin(self.target_rate(), self.max_margin)
+            rate_min = self.apply_buy_margin(self.target_price(), self.min_margin)
+            rate_max = self.apply_buy_margin(self.target_price(), self.max_margin)
             if (rate < rate_max) or (rate > rate_min):
                 yield offer
 
@@ -119,8 +119,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return sell offers with rates outside allowed margin range."""
         for offer in self.our_sell_offers(active_offers):
             rate = self.rate_sell(offer)
-            rate_min = self.apply_sell_margin(self.target_rate(), self.min_margin)
-            rate_max = self.apply_sell_margin(self.target_rate(), self.max_margin)
+            rate_min = self.apply_sell_margin(self.target_price(), self.min_margin)
+            rate_max = self.apply_sell_margin(self.target_price(), self.max_margin)
             if (rate < rate_min) or (rate > rate_max):
                 yield offer
 
@@ -133,31 +133,31 @@ class SaiMakerOtc(SaiKeeper):
         synchronize([transact.transact_async(self.default_options())
                      for transact in chain(self.new_buy_offer(active_offers), self.new_sell_offer(active_offers))])
 
-    def new_buy_offer(self, active_offers: list):
+    def new_sell_offer(self, active_offers: list):
         """If our WETH engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_buy_offers(active_offers))
+        total_amount = self.total_amount(self.our_sell_offers(active_offers))
         if total_amount < self.min_weth_amount:
             our_balance = self.gem.balance_of(self.our_address)
             have_amount = Wad.min(self.max_weth_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount / self.apply_buy_margin(self.target_rate(), self.avg_margin)
+                want_amount = have_amount * self.apply_buy_margin(self.target_price(), self.avg_margin)
                 yield self.otc.make(have_token=self.gem.address, have_amount=have_amount,
                                     want_token=self.sai.address, want_amount=want_amount)
 
-    def new_sell_offer(self, active_offers: list):
+    def new_buy_offer(self, active_offers: list):
         """If our SAI engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_sell_offers(active_offers))
+        total_amount = self.total_amount(self.our_buy_offers(active_offers))
         if total_amount < self.min_sai_amount:
             our_balance = self.sai.balance_of(self.our_address)
             have_amount = Wad.min(self.max_sai_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount * self.apply_sell_margin(self.target_rate(), self.avg_margin)
+                want_amount = have_amount / self.apply_sell_margin(self.target_price(), self.avg_margin)
                 yield self.otc.make(have_token=self.sai.address, have_amount=have_amount,
                                     want_token=self.gem.address, want_amount=want_amount)
 
-    def target_rate(self) -> Wad:
+    def target_price(self) -> Wad:
         ref_per_gem = Wad(DSValue(web3=self.web3, address=self.tub.pip()).read_as_int())
-        return self.tub.par() / ref_per_gem
+        return ref_per_gem / self.tub.par()
 
     @staticmethod
     def rate_buy(offer: OfferInfo) -> Wad:

--- a/keepers/sai_maker_otc.py
+++ b/keepers/sai_maker_otc.py
@@ -142,10 +142,7 @@ class SaiMakerOtc(SaiKeeper):
             our_balance = self.gem.balance_of(self.our_address)
             have_amount = Wad.min(self.max_weth_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-<<<<<<< HEAD
-=======
                 want_amount = have_amount * self.apply_sell_margin(self.target_price(), self.avg_margin)
->>>>>>> fac8419... (Fixed) match Oasis buy/sell convention; changed spread semantics
                 yield self.otc.make(have_token=self.gem.address, have_amount=have_amount,
                                     want_token=self.sai.address, want_amount=want_amount)
 
@@ -156,10 +153,7 @@ class SaiMakerOtc(SaiKeeper):
             our_balance = self.sai.balance_of(self.our_address)
             have_amount = Wad.min(self.max_sai_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-<<<<<<< HEAD
-=======
                 want_amount = have_amount / self.apply_buy_margin(self.target_price(), self.avg_margin)
->>>>>>> fac8419... (Fixed) match Oasis buy/sell convention; changed spread semantics
                 yield self.otc.make(have_token=self.sai.address, have_amount=have_amount,
                                     want_token=self.gem.address, want_amount=want_amount)
 

--- a/keepers/sai_maker_otc.py
+++ b/keepers/sai_maker_otc.py
@@ -91,11 +91,11 @@ class SaiMakerOtc(SaiKeeper):
     def our_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.owner == self.our_address, active_offers))
 
-    def our_sell_offers(self, active_offers: list):
+    def our_buy_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.sai.address and
                                          offer.sell_which_token == self.gem.address, self.our_offers(active_offers)))
 
-    def our_buy_offers(self, active_offers: list):
+    def our_sell_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.gem.address and
                                          offer.sell_which_token == self.sai.address, self.our_offers(active_offers)))
 
@@ -110,8 +110,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return buy offers with rates outside allowed margin range."""
         for offer in self.our_buy_offers(active_offers):
             rate = self.rate_buy(offer)
-            rate_min = self.apply_buy_margin(self.target_price(), self.min_margin)
-            rate_max = self.apply_buy_margin(self.target_price(), self.max_margin)
+            rate_min = self.apply_buy_margin(self.target_rate(), self.min_margin)
+            rate_max = self.apply_buy_margin(self.target_rate(), self.max_margin)
             if (rate < rate_max) or (rate > rate_min):
                 yield offer
 
@@ -119,8 +119,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return sell offers with rates outside allowed margin range."""
         for offer in self.our_sell_offers(active_offers):
             rate = self.rate_sell(offer)
-            rate_min = self.apply_sell_margin(self.target_price(), self.min_margin)
-            rate_max = self.apply_sell_margin(self.target_price(), self.max_margin)
+            rate_min = self.apply_sell_margin(self.target_rate(), self.min_margin)
+            rate_max = self.apply_sell_margin(self.target_rate(), self.max_margin)
             if (rate < rate_min) or (rate > rate_max):
                 yield offer
 
@@ -133,31 +133,31 @@ class SaiMakerOtc(SaiKeeper):
         synchronize([transact.transact_async(self.default_options())
                      for transact in chain(self.new_buy_offer(active_offers), self.new_sell_offer(active_offers))])
 
-    def new_sell_offer(self, active_offers: list):
+    def new_buy_offer(self, active_offers: list):
         """If our WETH engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_sell_offers(active_offers))
+        total_amount = self.total_amount(self.our_buy_offers(active_offers))
         if total_amount < self.min_weth_amount:
             our_balance = self.gem.balance_of(self.our_address)
             have_amount = Wad.min(self.max_weth_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount * self.apply_buy_margin(self.target_price(), self.avg_margin)
+                want_amount = have_amount / self.apply_buy_margin(self.target_rate(), self.avg_margin)
                 yield self.otc.make(have_token=self.gem.address, have_amount=have_amount,
                                     want_token=self.sai.address, want_amount=want_amount)
 
-    def new_buy_offer(self, active_offers: list):
+    def new_sell_offer(self, active_offers: list):
         """If our SAI engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_buy_offers(active_offers))
+        total_amount = self.total_amount(self.our_sell_offers(active_offers))
         if total_amount < self.min_sai_amount:
             our_balance = self.sai.balance_of(self.our_address)
             have_amount = Wad.min(self.max_sai_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount / self.apply_sell_margin(self.target_price(), self.avg_margin)
+                want_amount = have_amount * self.apply_sell_margin(self.target_rate(), self.avg_margin)
                 yield self.otc.make(have_token=self.sai.address, have_amount=have_amount,
                                     want_token=self.gem.address, want_amount=want_amount)
 
-    def target_price(self) -> Wad:
+    def target_rate(self) -> Wad:
         ref_per_gem = Wad(DSValue(web3=self.web3, address=self.tub.pip()).read_as_int())
-        return ref_per_gem / self.tub.par()
+        return self.tub.par() / ref_per_gem
 
     @staticmethod
     def rate_buy(offer: OfferInfo) -> Wad:

--- a/keepers/sai_maker_otc.py
+++ b/keepers/sai_maker_otc.py
@@ -91,11 +91,11 @@ class SaiMakerOtc(SaiKeeper):
     def our_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.owner == self.our_address, active_offers))
 
-    def our_sell_offers(self, active_offers: list):
+    def our_buy_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.sai.address and
                                          offer.sell_which_token == self.gem.address, self.our_offers(active_offers)))
 
-    def our_buy_offers(self, active_offers: list):
+    def our_sell_offers(self, active_offers: list):
         return list(filter(lambda offer: offer.buy_which_token == self.gem.address and
                                          offer.sell_which_token == self.sai.address, self.our_offers(active_offers)))
 
@@ -110,8 +110,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return buy offers with rates outside allowed margin range."""
         for offer in self.our_buy_offers(active_offers):
             rate = self.rate_buy(offer)
-            rate_min = self.apply_buy_margin(self.target_price(), self.min_margin)
-            rate_max = self.apply_buy_margin(self.target_price(), self.max_margin)
+            rate_min = self.apply_buy_margin(self.target_rate(), self.min_margin)
+            rate_max = self.apply_buy_margin(self.target_rate(), self.max_margin)
             if (rate < rate_max) or (rate > rate_min):
                 yield offer
 
@@ -119,8 +119,8 @@ class SaiMakerOtc(SaiKeeper):
         """Return sell offers with rates outside allowed margin range."""
         for offer in self.our_sell_offers(active_offers):
             rate = self.rate_sell(offer)
-            rate_min = self.apply_sell_margin(self.target_price(), self.min_margin)
-            rate_max = self.apply_sell_margin(self.target_price(), self.max_margin)
+            rate_min = self.apply_sell_margin(self.target_rate(), self.min_margin)
+            rate_max = self.apply_sell_margin(self.target_rate(), self.max_margin)
             if (rate < rate_min) or (rate > rate_max):
                 yield offer
 
@@ -133,31 +133,31 @@ class SaiMakerOtc(SaiKeeper):
         synchronize([transact.transact_async(self.default_options())
                      for transact in chain(self.new_buy_offer(active_offers), self.new_sell_offer(active_offers))])
 
-    def new_sell_offer(self, active_offers: list):
+    def new_buy_offer(self, active_offers: list):
         """If our WETH engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_sell_offers(active_offers))
+        total_amount = self.total_amount(self.our_buy_offers(active_offers))
         if total_amount < self.min_weth_amount:
             our_balance = self.gem.balance_of(self.our_address)
             have_amount = Wad.min(self.max_weth_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount * self.apply_sell_margin(self.target_price(), self.avg_margin)
+                want_amount = have_amount / self.apply_buy_margin(self.target_rate(), self.avg_margin)
                 yield self.otc.make(have_token=self.gem.address, have_amount=have_amount,
                                     want_token=self.sai.address, want_amount=want_amount)
 
-    def new_buy_offer(self, active_offers: list):
+    def new_sell_offer(self, active_offers: list):
         """If our SAI engagement is below the minimum amount, yield a new offer up to the maximum amount."""
-        total_amount = self.total_amount(self.our_buy_offers(active_offers))
+        total_amount = self.total_amount(self.our_sell_offers(active_offers))
         if total_amount < self.min_sai_amount:
             our_balance = self.sai.balance_of(self.our_address)
             have_amount = Wad.min(self.max_sai_amount - total_amount, our_balance)
             if have_amount > Wad(0):
-                want_amount = have_amount / self.apply_buy_margin(self.target_price(), self.avg_margin)
+                want_amount = have_amount * self.apply_sell_margin(self.target_rate(), self.avg_margin)
                 yield self.otc.make(have_token=self.sai.address, have_amount=have_amount,
                                     want_token=self.gem.address, want_amount=want_amount)
 
-    def target_price(self) -> Wad:
+    def target_rate(self) -> Wad:
         ref_per_gem = Wad(DSValue(web3=self.web3, address=self.tub.pip()).read_as_int())
-        return ref_per_gem / self.tub.par()
+        return self.tub.par() / ref_per_gem
 
     @staticmethod
     def rate_buy(offer: OfferInfo) -> Wad:


### PR DESCRIPTION
For accounting purposes, it's nicer if the keeper places an order for 3210.12 SAI at a price of 321.01 SAI per ETH, instead of 3210.123524345 SAI at a price of 321.012535 SAI per ETH. So we should let the user specify a number of decimal places (defaulting to 2) to round order price to (and possibly also round order size, separately).

I will make more commits (and tests) later, for now we start with rounding `Wad`s.