### PR TITLE
Adding necessary package

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ pip install -r requirements.txt
 ### Known macOS issues
 
 In order for the requirements to install correctly on _macOS_, please install
-`openssl` and `libtool` using [Homebrew](https://brew.sh/):
+`openssl`, `libtool` and `pkg-config` using [Homebrew](https://brew.sh/):
 ```
-brew install openssl libtool
+brew install openssl libtool pkg-config
 ```
 
 and set the `LDFLAGS` environment variable before you run `pip install -r requirements.txt`:


### PR DESCRIPTION
While installing the requirements I realized I was missing `pkg-config`, which seems to be necessary to complete it (at least using `pip3`)